### PR TITLE
Add configurable startup delay before power latch activation

### DIFF
--- a/Inc/config.h
+++ b/Inc/config.h
@@ -108,6 +108,9 @@
 #define TEMP_WARNING            600       // annoying fast beeps [°C * 10].  Here 60.0 °C
 #define TEMP_POWEROFF_ENABLE    0         // to poweroff or not to poweroff, 1 or 0, DO NOT ACTIVITE WITHOUT CALIBRATION!
 #define TEMP_POWEROFF           650       // overheat poweroff. (while not driving) [°C * 10]. Here 65.0 °C
+
+// ############################### STARTUP DELAY ################################
+#define STARTUP_DELAY_MS        500       // startup delay [ms] before power latch is activated. Prevents spurious power-on from brief supply glitches (e.g. UART back-powering).
 // ######################## END OF TEMPERATURE ###############################
 
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -193,6 +193,8 @@ int main(void) {
 
   SystemClock_Config();
 
+  HAL_Delay(STARTUP_DELAY_MS); // Wait to prevent spurious power-on when MCU is briefly back-powered (e.g. via UART). If the supply disappears, the MCU will simply lose power and not latch on.
+
   __HAL_RCC_DMA1_CLK_DISABLE();
   MX_GPIO_Init();
   MX_TIM_Init();


### PR DESCRIPTION
Add STARTUP_DELAY_MS to prevent the board from latching on when the MCU is briefly back-powered through unexpected means such as UART. The delay is applied before the self-latch GPIO is set, assuming a transient power source will fade during the window and never engage the latch.